### PR TITLE
Change opencv3 dep to libopencv3 to adapt to bionic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>opencv3</build_depend>
+  <build_depend>libopencv3</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
@@ -32,7 +32,7 @@
   <run_depend>rosconsole</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>opencv3</run_depend>
+  <run_depend>libopencv3</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>libpcl-all</run_depend>


### PR DESCRIPTION
Update opencv3 dep to our custom libopencv3 that adapts for bionic

closes [issue](https://github.com/Brazilian-Institute-of-Robotics/mccr_robot/issues/75)